### PR TITLE
Laiban Instagram mobile app verification

### DIFF
--- a/app-ads.txt
+++ b/app-ads.txt
@@ -1,0 +1,2 @@
+# Laiban Instagram integration.
+facebook.com, 1490583365, DIRECT, c3e20eee3f780d68


### PR DESCRIPTION
File used by app developers to declare which authorized digital sellers.
File must be placed in the root folder of URL "https://laiban.helsingborg.se/".

Refs for file info and purpose:
https://developers.facebook.com/docs/development/release/mobile-app-verification